### PR TITLE
Implement dark theme for user interface

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -7,11 +7,19 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
     <style>
-        .profit { color: #28a745; }
-        .loss { color: #dc3545; }
-        .card { margin-bottom: 20px; }
-        .metric-value { font-size: 1.5em; font-weight: bold; }
+        body { background-color: #121212; color: #FFFFFF; }
+        .card { background-color: #1E1E1E; border: 1px solid #2E2E2E; color: #FFFFFF; margin-bottom: 20px; }
+        .card-header { background-color: #282828; color: #FFFFFF; border-bottom: 1px solid #2E2E2E;}
+        .table { color: #FFFFFF; }
+        .table thead th { border-bottom: 2px solid #2E2E2E; }
+        .table tbody tr { border-bottom: 1px solid #2E2E2E; }
+        .table tbody tr:hover { background-color: #282828; }
+        .profit { color: #33cc33; }
+        .loss { color: #ff4d4d; }
+        .metric-value { font-size: 1.5em; font-weight: bold; color: #FFFFFF; }
         .token-info { font-size: 0.9em; }
+        h2, h5 { color: #FFFFFF; }
+        a { color: #17a2b8; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
This commit introduces a dark theme to the Solana Trading Bot Dashboard.

The following changes were made to static/index.html:
- Changed the background color of the page to a dark grey (#121212).
- Set the default text color to white (#FFFFFF) for better contrast.
- Updated card backgrounds to a darker shade (#1E1E1E) and card headers to a slightly lighter dark shade (#282828).
- Adjusted table colors, including text, headers, and row hover effects, to fit the dark theme.
- Modified profit and loss indicator colors to be brighter and more visible against dark backgrounds (#33cc33 for profit, #ff4d4d for loss).
- Ensured headings, metric values, and link colors are updated for readability in the new dark theme.

These changes enhance the visual appearance of the dashboard and provide a more user-friendly experience in low-light environments.