### PR TITLE
Fix: RugCheck Score Parsing and Feat: Scanner Metrics API

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,10 +26,13 @@ async def get_status():
             'current_price': current_price
         }
 
+    scanner_metrics_data = scanner.get_scanner_metrics()
+
     return {
-        "metrics": trader.performance_metrics,
+        "trader_metrics": trader.performance_metrics, # Renamed "metrics" to "trader_metrics"
         "active_positions": active_positions,
-        "position_history": trader.position_history
+        "position_history": trader.position_history,
+        "scanner_metrics": scanner_metrics_data # Added scanner_metrics
     }
 
 async def start_bot():

--- a/trading_bot/scanner.py
+++ b/trading_bot/scanner.py
@@ -35,10 +35,12 @@ class TokenScanner:
         self.session: Optional[aiohttp.ClientSession] = None
         self.potential_tokens = []
         self.scan_count = 0
-        # Initialize with a static JWT from config if provided.
-        # This will be overwritten by a dynamically generated JWT if dynamic generation is successful.
         self.rugcheck_jwt: Optional[str] = STATIC_RUGCHECK_JWT
         self.rugcheck_jwt_generation_attempted: bool = False
+        # Metrics for unique tokens scanned
+        self.unique_tokens_scanned_today = set()
+        self.last_scan_reset_time = datetime.now()
+        self.total_unique_tokens_ever = set()
 
     async def _ensure_rugcheck_jwt(self) -> None:
         """
@@ -224,6 +226,12 @@ class TokenScanner:
     async def scan_new_tokens(self):
         """Phase 1 & 2 & 3: Discover, Fetch Details, and Analyze Tokens."""
         try:
+            # Daily reset logic for unique scanned tokens
+            if datetime.now() - self.last_scan_reset_time > timedelta(hours=24):
+                logger.info(f"🔄 Resetting daily unique token scan count. Previous count: {len(self.unique_tokens_scanned_today)}")
+                self.unique_tokens_scanned_today = set()
+                self.last_scan_reset_time = datetime.now()
+
             # Use DEXSCREENER_TOKEN_PROFILES_API for Phase 1
             params = {"chainId": "solana"}
             logger.info(f"🔄 Starting scan for new token profiles using {DEXSCREENER_TOKEN_PROFILES_API} with params {params}")
@@ -238,6 +246,10 @@ class TokenScanner:
                     if not base_token_address:
                         logger.debug("Skipping profile due to missing tokenAddress. ⏭️")
                         continue
+
+                    # Add to unique scanned sets
+                    self.unique_tokens_scanned_today.add(base_token_address)
+                    self.total_unique_tokens_ever.add(base_token_address)
 
                     base_token_address_short = _shorten_address(base_token_address)
                     token_symbol_from_profile = token_profile.get('symbol') or token_profile.get('name') or "UnknownSymbol"
@@ -354,6 +366,54 @@ class TokenScanner:
             return float('inf')
         return 0.0 # No buys or sells in H1
 
+    def get_scanner_metrics(self) -> dict:
+        """Returns a dictionary of current scanner metrics, including recent potential tokens."""
+        recent_tokens_details = []
+        # Get the last 3 tokens, or fewer if not enough are present
+        num_to_fetch = min(3, len(self.potential_tokens))
+
+        for token_entry in self.potential_tokens[-num_to_fetch:]:
+            detailed_pair_data = token_entry.get('detailed_pair_data', {})
+
+            # Symbol prioritization
+            symbol = detailed_pair_data.get('baseToken', {}).get('symbol')
+            if not symbol: # Fallback to symbol stored directly in token_entry (from phase 1 profile)
+                symbol = token_entry.get('symbol', 'N/A')
+
+            pair_address = token_entry.get('pair_address', 'N/A')
+            pair_address_short = _shorten_address(pair_address) if pair_address != 'N/A' else 'N/A'
+
+            price_usd_raw = detailed_pair_data.get('priceUsd')
+            price_usd_str = "N/A"
+            if price_usd_raw is not None:
+                try:
+                    price_usd_str = f"{float(price_usd_raw):.6f}" # Format to 6 decimal places
+                except (ValueError, TypeError):
+                    price_usd_str = str(price_usd_raw) # Keep original if not floatable
+
+            discovered_at_raw = token_entry.get('phase1_discovered_at') or token_entry.get('timestamp')
+            discovered_at_iso = "N/A"
+            if isinstance(discovered_at_raw, datetime):
+                discovered_at_iso = discovered_at_raw.isoformat()
+            elif discovered_at_raw is not None: # If it's already a string or other type
+                discovered_at_iso = str(discovered_at_raw)
+
+            recent_tokens_details.append({
+                "symbol": symbol,
+                "pair_address_short": pair_address_short,
+                "price_usd": price_usd_str,
+                "discovered_at": discovered_at_iso
+            })
+
+        return {
+            "unique_tokens_scanned_today": len(self.unique_tokens_scanned_today),
+            "total_unique_tokens_scanned_all_time": len(self.total_unique_tokens_ever),
+            "potential_tokens_count": len(self.potential_tokens),
+            "potential_tokens_recent": recent_tokens_details,
+            "rugcheck_jwt_status": "Loaded" if self.rugcheck_jwt else "Not Loaded",
+            "last_daily_reset_at": self.last_scan_reset_time.isoformat()
+        }
+
     async def verify_token_safety_rugcheck(self, session: aiohttp.ClientSession, token_address: str) -> dict:
         """
         Verifies token safety using the RugCheck.xyz API endpoint (/v1/tokens/{id}/report/summary).
@@ -395,20 +455,51 @@ class TokenScanner:
                 is_safe = True; reasons = []
                 score = response_data.get('score')
                 score_normalised_value = response_data.get('scoreNormalised')
+                logger.debug(f"RugCheck raw scores for {token_address}: score='{score}', scoreNormalised='{score_normalised_value}'")
 
-                # Score check (RUGCHECK_SCORE_THRESHOLD is min acceptable, higher is better for score_normalised)
-                check_score = score_normalised_value if score_normalised_value is not None else score
+                # Score check (Lower scores are better. RUGCHECK_SCORE_THRESHOLD is the max acceptable score.)
+                VALID_SCORE_MIN = 0.0
+                VALID_SCORE_MAX = 150.0 # Assuming scores don't realistically go much higher
+
+                check_score = None
+                selected_score_field_name = None
+
+                # Try scoreNormalised first
+                if score_normalised_value is not None:
+                    try:
+                        temp_score_norm = float(score_normalised_value)
+                        if VALID_SCORE_MIN <= temp_score_norm <= VALID_SCORE_MAX:
+                            check_score = temp_score_norm
+                            selected_score_field_name = "scoreNormalised"
+                        else:
+                            logger.warning(f"RugCheck: scoreNormalised ('{score_normalised_value}') for {token_address} is outside valid range ({VALID_SCORE_MIN}-{VALID_SCORE_MAX}).")
+                    except (ValueError, TypeError):
+                        logger.warning(f"RugCheck: scoreNormalised ('{score_normalised_value}') for {token_address} is not a valid number.")
+
+                # If scoreNormalised wasn't valid or used, try 'score'
+                if check_score is None and score is not None:
+                    try:
+                        temp_score = float(score)
+                        if VALID_SCORE_MIN <= temp_score <= VALID_SCORE_MAX:
+                            check_score = temp_score
+                            selected_score_field_name = "score"
+                        else:
+                            logger.warning(f"RugCheck: score ('{score}') for {token_address} is outside valid range ({VALID_SCORE_MIN}-{VALID_SCORE_MAX}).")
+                    except (ValueError, TypeError):
+                        logger.warning(f"RugCheck: score ('{score}') for {token_address} is not a valid number.")
+
+                # Now, process check_score
                 if check_score is None:
-                    is_safe = False
-                    reasons.append("Score (normalised or raw) missing from RugCheck.")
-                elif not isinstance(check_score, (int, float)):
-                    is_safe = False
-                    reasons.append(f"Score ({check_score}) from RugCheck is not numeric.")
-                elif check_score > RUGCHECK_SCORE_THRESHOLD: # Changed from < to >
-                    is_safe = False
-                    reasons.append(f"Score ({check_score}) is above threshold ({RUGCHECK_SCORE_THRESHOLD}).") # Updated reason
+                    is_safe = False # Mark as unsafe if no valid score could be determined
+                    reasons.append("No valid score (normalised or raw) available from RugCheck after validation.")
+                    logger.warning(f"RugCheck: No valid score found for {token_address} after checking score='{score}' and scoreNormalised='{score_normalised_value}'.")
+                else:
+                    logger.info(f"RugCheck: Using '{selected_score_field_name}' value {check_score:.2f} for token {token_address} against threshold {RUGCHECK_SCORE_THRESHOLD}.")
+                    if check_score > RUGCHECK_SCORE_THRESHOLD:
+                        is_safe = False
+                        reasons.append(f"Score ({check_score:.2f} from {selected_score_field_name}) is above threshold ({RUGCHECK_SCORE_THRESHOLD}).")
 
-                # Risks field handling
+                # Risks field handling (remains the same, processes `is_safe` which might have been set by score check)
                 api_risks_raw = response_data.get('risks') # Get raw value first
                 api_risks_for_iteration = [] # Default to empty list for iteration logic
 

--- a/trading_bot/tests/test_main.py
+++ b/trading_bot/tests/test_main.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch, AsyncMock # AsyncMock might be needed if we don't simplify trader calls
+from fastapi.testclient import TestClient
+from datetime import datetime
+
+# Import app and global objects from main.py
+# Ensure that main.py can be imported in a test environment
+# (e.g., it doesn't start a web server immediately upon import if not __main__)
+from trading_bot.main import app, scanner, trader # Assuming scanner and trader are global instances in main
+
+class TestMainAPI(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient(app)
+        # Reset or set default states for global trader/scanner objects if necessary,
+        # though patching their methods/attributes is often cleaner for API tests.
+
+    @patch('trading_bot.main.scanner.get_scanner_metrics')
+    # If trader.get_token_price was complex or made external calls, we'd mock it:
+    # @patch('trading_bot.main.trader.get_token_price', new_callable=AsyncMock)
+    def test_get_api_status(self, mock_get_scanner_metrics): #, mock_get_token_price
+        # 1. Prepare mock data for scanner.get_scanner_metrics()
+        mock_scanner_data = {
+            "unique_tokens_scanned_today": 15,
+            "total_unique_tokens_scanned_all_time": 150,
+            "potential_tokens_count": 7,
+            "potential_tokens_recent": [
+                {"symbol": "TOK1", "pair_address_short": "p1..s1", "price_usd": "1.2345", "discovered_at": datetime.now().isoformat()},
+                {"symbol": "TOK2", "pair_address_short": "p2..s2", "price_usd": "0.005", "discovered_at": (datetime.now() - timedelta(hours=1)).isoformat()},
+            ],
+            "rugcheck_jwt_status": "Loaded",
+            "last_daily_reset_at": (datetime.now() - timedelta(hours=5)).isoformat()
+        }
+        mock_get_scanner_metrics.return_value = mock_scanner_data
+
+        # 2. Prepare mock data/state for trader object properties accessed by the endpoint
+        # To avoid trader.get_token_price calls, ensure active_positions is empty for this test
+        original_active_positions = trader.active_positions
+        original_performance_metrics = trader.performance_metrics
+        original_position_history = trader.position_history
+
+        trader.active_positions = {} # No active positions, so get_token_price won't be called
+        trader.performance_metrics = {"profit_loss": 100.0, "win_rate": 0.75}
+        trader.position_history = [{"symbol": "OLDTOK", "outcome": "profit", "pnl": 50.0}]
+
+        # If we had active_positions that trigger get_token_price:
+        # mock_get_token_price.return_value = 1.23 # Example mock price
+
+        # 3. Make API Call
+        response = self.client.get("/api/status")
+
+        # 4. Assert Status Code
+        self.assertEqual(response.status_code, 200)
+
+        # 5. Assert Response Content
+        data = response.json()
+
+        self.assertIn("scanner_metrics", data)
+        self.assertEqual(data["scanner_metrics"], mock_scanner_data)
+        mock_get_scanner_metrics.assert_called_once() # Verify the mock was called
+
+        self.assertIn("trader_metrics", data)
+        self.assertEqual(data["trader_metrics"], trader.performance_metrics)
+
+        self.assertIn("active_positions", data)
+        self.assertEqual(data["active_positions"], {}) # As we set it to empty
+
+        self.assertIn("position_history", data)
+        self.assertEqual(data["position_history"], trader.position_history)
+
+        # Restore original trader attributes if they were modified directly on the global instance
+        trader.active_positions = original_active_positions
+        trader.performance_metrics = original_performance_metrics
+        trader.position_history = original_position_history
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trading_bot/tests/test_scanner.py
+++ b/trading_bot/tests/test_scanner.py
@@ -164,22 +164,150 @@ class TestTokenScanner(unittest.IsolatedAsyncioTestCase):
 
     # ... (Other _ensure_rugcheck_jwt tests can remain similar, ensuring fresh TokenScanner for config patches)
 
+    async def mock_rugcheck_response(self, status=200, score=None, score_normalised=None, risks=None, error_message=None):
+        mock_resp = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_resp.status = status
+        mock_resp.__aenter__.return_value = mock_resp
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
 
-    # --- Tests for verify_token_safety_rugcheck (Uses the main mock_get_side_effect) ---
+        if error_message: # Simulate API error before JSON parsing
+            mock_resp.text = AsyncMock(return_value=error_message)
+            mock_resp.json = AsyncMock(side_effect=aiohttp.ContentTypeError(None, None)) # Simulate failure if .json() is called
+            return mock_resp
+
+        response_json = {}
+        if score is not None:
+            response_json['score'] = score
+        if score_normalised is not None:
+            response_json['scoreNormalised'] = score_normalised
+        response_json['risks'] = risks if risks is not None else []
+
+        mock_resp.json = AsyncMock(return_value=response_json)
+        mock_resp.text = AsyncMock(return_value=json.dumps(response_json))
+        return mock_resp
+
+    # --- Tests for verify_token_safety_rugcheck (Updated with specific score logic tests) ---
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
     @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
-    async def test_rugcheck_safe_token(self, mock_session_get):
-        mock_session_get.side_effect = mock_get_side_effect
-        self.scanner.rugcheck_jwt = "test_jwt" # Assume JWT is set for this test
-        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "any_safe_token_addr")
+    async def test_rugcheck_scoreNormalised_preferred_and_valid(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=5, score=50)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
         self.assertTrue(result['is_safe'])
-        self.assertEqual(result['score_normalised'], MOCK_RUGCHECK_RESPONSE_SAFE['scoreNormalised'])
+        self.assertEqual(result['score_normalised'], 5)
+        self.assertEqual(result['score'], 50)
+        self.assertNotIn("Score (5.00 from scoreNormalised) is above threshold (10).", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_scoreNormalised_invalid_range_uses_valid_score(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=160, score=8) # 160 is out of 0-150 range
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertTrue(result['is_safe']) # score=8 is used
+        self.assertEqual(result['score_normalised'], 160)
+        self.assertEqual(result['score'], 8)
+        self.assertNotIn("Score (8.00 from score) is above threshold (10).", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_scoreNormalised_non_numeric_uses_valid_score(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised="error", score=8)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertTrue(result['is_safe']) # score=8 is used
+        self.assertEqual(result['score_normalised'], "error")
+        self.assertEqual(result['score'], 8)
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_scoreNormalised_valid_score_absent(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=5, score=None)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertTrue(result['is_safe'])
+        self.assertEqual(result['score_normalised'], 5)
+        self.assertIsNone(result['score'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_scoreNormalised_absent_score_valid(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=None, score=5)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertTrue(result['is_safe'])
+        self.assertIsNone(result['score_normalised'])
+        self.assertEqual(result['score'], 5)
 
     @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
-    async def test_rugcheck_unsafe_token(self, mock_session_get):
-        mock_session_get.side_effect = mock_get_side_effect
-        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "any_unsafe_token_addr")
+    async def test_rugcheck_both_scores_invalid_range(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=170, score=-10)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
         self.assertFalse(result['is_safe'])
-        self.assertEqual(result['score_normalised'], MOCK_RUGCHECK_RESPONSE_UNSAFE['scoreNormalised'])
+        self.assertIn("No valid score (normalised or raw) available from RugCheck after validation.", result['reasons'])
+
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_both_scores_non_numeric(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised="error1", score="error2")
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertFalse(result['is_safe'])
+        self.assertIn("No valid score (normalised or raw) available from RugCheck after validation.", result['reasons'])
+
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_both_scores_none(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=None, score=None)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertFalse(result['is_safe'])
+        self.assertIn("No valid score (normalised or raw) available from RugCheck after validation.", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_score_at_threshold(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=10)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertTrue(result['is_safe']) # Score 10 should be safe if threshold is 10
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_score_just_above_threshold(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=10.1)
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertFalse(result['is_safe'])
+        self.assertIn("Score (10.10 from scoreNormalised) is above threshold (10).", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_score_at_valid_max_above_threshold(self, mock_session_get):
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=150.0) # VALID_SCORE_MAX is 150
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertFalse(result['is_safe'])
+        self.assertIn("Score (150.00 from scoreNormalised) is above threshold (10).", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 20) # Set threshold higher for this test
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_problematic_reported_value(self, mock_session_get):
+        # scoreNormalised = "501" (out of range), score = "16.4" (valid, below threshold 20)
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised="501", score="16.4")
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertTrue(result['is_safe']) # Should use score 16.4, which is < 20
+        self.assertEqual(result['score_normalised'], "501") # Raw value preserved
+        self.assertEqual(result['score'], "16.4")       # Raw value preserved
+        self.assertNotIn(f"Score (16.40 from score) is above threshold (20).", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 5) # Set threshold lower for this test
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_problematic_reported_value_unsafe(self, mock_session_get):
+        # scoreNormalised = "501" (out of range), score = "16.4" (valid, BUT above threshold 5)
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised="501", score="16.4")
+        result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertFalse(result['is_safe']) # Should use score 16.4, which is > 5
+        self.assertIn(f"Score (16.40 from score) is above threshold (5).", result['reasons'])
+
+    @patch('trading_bot.scanner.RUGCHECK_SCORE_THRESHOLD', 10)
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock)
+    async def test_rugcheck_critical_risk_overrides_good_score(self, mock_session_get):
+        critical_risks = [{"name": "Honeypot", "level": "critical", "description": "It's a trap!"}]
+        mock_session_get.return_value = await self.mock_rugcheck_response(score_normalised=5, risks=critical_risks) # Good score
+        with patch('trading_bot.scanner.RUGCHECK_CRITICAL_RISK_NAMES', ["Honeypot"]):
+            result = await self.scanner.verify_token_safety_rugcheck(self.scanner.session, "token_addr")
+        self.assertFalse(result['is_safe'])
+        self.assertTrue(any("Critical risk: Honeypot" in reason for reason in result['reasons']))
 
     # --- Tests for analyze_token_metrics (Updated for new data structure and signature) ---
     @patch('trading_bot.scanner.TARGET_MARKET_CAP_TO_SCAN', MOCK_DETAILED_PAIR_DATA_VALID['fdv'] + 1000) # Make current fdv too low
@@ -340,6 +468,176 @@ class TestTokenScanner(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(called_search_api, "Search API should not have been called due to pump.fun filter mismatch.")
         mock_rugcheck_method.assert_not_called()
+
+    # --- Tests for get_scanner_metrics ---
+    def _create_mock_potential_token(self, mint_addr, symbol_profile, symbol_pair, pair_addr, price_usd, discovered_mins_ago):
+        discovery_time = datetime.now() - timedelta(minutes=discovered_mins_ago)
+        return {
+            'address': mint_addr,
+            'symbol': symbol_profile, # This is the one from Phase 1 profile
+            'pair_address': pair_addr,
+            'phase1_discovered_at': discovery_time,
+            'timestamp': discovery_time,
+            'detailed_pair_data': {
+                'baseToken': {'symbol': symbol_pair}, # This is symbol from pair data
+                'pairAddress': pair_addr,
+                'priceUsd': str(price_usd) # Store as string, as API might
+            },
+            # Add other fields if get_scanner_metrics starts using them
+        }
+
+    def test_get_scanner_metrics_initial_state(self):
+        initial_time = self.scanner.last_scan_reset_time # Capture before calling
+        metrics = self.scanner.get_scanner_metrics()
+        self.assertEqual(metrics['unique_tokens_scanned_today'], 0)
+        self.assertEqual(metrics['total_unique_tokens_scanned_all_time'], 0)
+        self.assertEqual(metrics['potential_tokens_count'], 0)
+        self.assertEqual(metrics['potential_tokens_recent'], [])
+        self.assertEqual(metrics['rugcheck_jwt_status'], "Not Loaded") # Assuming default setUp state
+        self.assertEqual(metrics['last_daily_reset_at'], initial_time.isoformat())
+
+    def test_get_scanner_metrics_after_scanning_some_tokens(self):
+        # Manually populate scanner state
+        self.scanner.unique_tokens_scanned_today = {'addr1', 'addr2'}
+        self.scanner.total_unique_tokens_ever = {'addr1', 'addr2', 'addr3'}
+
+        token1_time = datetime.now() - timedelta(minutes=10)
+        token2_time = datetime.now() - timedelta(minutes=5)
+
+        self.scanner.potential_tokens = [
+            self._create_mock_potential_token("addr1", "SYM1P", "SYM1", "pair1", 1.0, 10),
+            self._create_mock_potential_token("addr2", "SYM2P", "SYM2", "pair2", 2.55555555, 5)
+        ]
+        self.scanner.potential_tokens[0]['phase1_discovered_at'] = token1_time
+        self.scanner.potential_tokens[1]['phase1_discovered_at'] = token2_time
+
+
+        metrics = self.scanner.get_scanner_metrics()
+
+        self.assertEqual(metrics['unique_tokens_scanned_today'], 2)
+        self.assertEqual(metrics['total_unique_tokens_scanned_all_time'], 3)
+        self.assertEqual(metrics['potential_tokens_count'], 2)
+        self.assertEqual(len(metrics['potential_tokens_recent']), 2)
+
+        # Check recent token details (order is latest first if sliced with [-N:])
+        # Actually, the current implementation takes last N, so order is preserved.
+        recent1 = metrics['potential_tokens_recent'][0]
+        self.assertEqual(recent1['symbol'], 'SYM1') # From pair data
+        self.assertTrue('pair1' in recent1['pair_address_short'])
+        self.assertEqual(recent1['price_usd'], "1.000000")
+        self.assertEqual(recent1['discovered_at'], token1_time.isoformat())
+
+        recent2 = metrics['potential_tokens_recent'][1]
+        self.assertEqual(recent2['symbol'], 'SYM2')
+        self.assertTrue('pair2' in recent2['pair_address_short'])
+        self.assertEqual(recent2['price_usd'], "2.555556") # Check rounding/formatting
+        self.assertEqual(recent2['discovered_at'], token2_time.isoformat())
+
+    @patch('trading_bot.scanner.datetime') # Mock datetime module within scanner.py
+    @patch('aiohttp.ClientSession.get', new_callable=AsyncMock) # Mock API calls during scan
+    async def test_get_scanner_metrics_daily_reset(self, mock_session_get, mock_datetime):
+        # Setup initial time and add some scanned tokens
+        initial_real_time = datetime.now()
+        mock_datetime.now.return_value = initial_real_time
+        self.scanner.last_scan_reset_time = initial_real_time
+        self.scanner.unique_tokens_scanned_today = {'addr1', 'addr2'}
+        self.scanner.total_unique_tokens_ever = {'addr1', 'addr2', 'addr3'}
+
+        metrics_before_reset = self.scanner.get_scanner_metrics()
+        self.assertEqual(metrics_before_reset['unique_tokens_scanned_today'], 2)
+        self.assertEqual(metrics_before_reset['last_daily_reset_at'], initial_real_time.isoformat())
+
+        # Simulate time passing (25 hours later)
+        time_after_25_hours = initial_real_time + timedelta(hours=25)
+        mock_datetime.now.return_value = time_after_25_hours
+
+        # Mock the API call within scan_new_tokens to return empty list,
+        # so it runs quickly and triggers reset logic without processing tokens.
+        mock_session_get.side_effect = mock_get_side_effect # Use general mock, ensure it can return empty profiles
+
+        # For this specific test, make sure token profiles API returns empty
+        async def empty_profile_side_effect(url, params=None, **kwargs):
+            mock_resp = AsyncMock(spec=aiohttp.ClientResponse); mock_resp.status = 200
+            mock_resp.__aenter__.return_value = mock_resp; mock_resp.__aexit__ = AsyncMock(return_value=None)
+            if DEXSCREENER_TOKEN_PROFILES_API_VAL == url:
+                mock_resp.json = AsyncMock(return_value=[]) # Empty list of profiles
+            else: # Fallback to general mock for other potential calls (e.g. rugcheck if any token slipped through)
+                return await mock_get_side_effect(url, params, **kwargs)
+            mock_resp.text = AsyncMock(return_value=json.dumps(await mock_resp.json()))
+            return mock_resp
+        mock_session_get.side_effect = empty_profile_side_effect
+
+        await self.scanner.scan_new_tokens() # This should trigger the reset
+
+        metrics_after_reset = self.scanner.get_scanner_metrics()
+        self.assertEqual(metrics_after_reset['unique_tokens_scanned_today'], 0)
+        self.assertEqual(metrics_after_reset['total_unique_tokens_scanned_all_time'], 3) # Should not change
+        self.assertEqual(metrics_after_reset['last_daily_reset_at'], time_after_25_hours.isoformat())
+
+
+    def test_get_scanner_metrics_potential_tokens_recent_limit_and_formatting(self):
+        now = datetime.now()
+        self.scanner.potential_tokens = [
+            self._create_mock_potential_token("addr1", "S1P", "S1", "pair1", 0.000012345, 60), # Oldest
+            self._create_mock_potential_token("addr2", "S2P", "S2", "pair2", 2.0, 30),
+            self._create_mock_potential_token("addr3", "S3P", "S3", "pair3", 30.12, 10),
+            self._create_mock_potential_token("addr4", "S4P", "S4", "pair4", 123.0, 1)    # Newest
+        ]
+        # Update timestamps precisely
+        for i, mins_ago in enumerate([60,30,10,1]):
+            self.scanner.potential_tokens[i]['phase1_discovered_at'] = now - timedelta(minutes=mins_ago)
+
+
+        metrics = self.scanner.get_scanner_metrics()
+        self.assertEqual(len(metrics['potential_tokens_recent']), 3) # Max 3
+        # Tokens should be the latest 3: addr4, addr3, addr2
+        self.assertEqual(metrics['potential_tokens_recent'][0]['symbol'], 'S2') # -N returns last N items in original order
+        self.assertEqual(metrics['potential_tokens_recent'][1]['symbol'], 'S3')
+        self.assertEqual(metrics['potential_tokens_recent'][2]['symbol'], 'S4')
+
+        # Test formatting for one of them
+        token_s4_details = metrics['potential_tokens_recent'][2]
+        self.assertEqual(token_s4_details['price_usd'], "123.000000")
+        self.assertEqual(token_s4_details['discovered_at'], (now - timedelta(minutes=1)).isoformat())
+        self.assertTrue("pair4" in token_s4_details['pair_address_short'])
+
+        # Test with missing detailed_pair_data and priceUsd
+        missing_data_token_time = now - timedelta(minutes=5)
+        self.scanner.potential_tokens.append({
+            'address': 'addr5_missing', 'symbol': 'S5P_NODETAIL', 'pair_address': 'pair5miss',
+            'phase1_discovered_at': missing_data_token_time, 'timestamp': missing_data_token_time,
+            'detailed_pair_data': {} # Missing priceUsd and baseToken.symbol
+        })
+        metrics_with_missing = self.scanner.get_scanner_metrics()
+        self.assertEqual(len(metrics_with_missing['potential_tokens_recent']), 3)
+
+        # The newest one is addr5_missing
+        token_s5_details = metrics_with_missing['potential_tokens_recent'][2]
+        self.assertEqual(token_s5_details['symbol'], 'S5P_NODETAIL') # Fallback to profile symbol
+        self.assertEqual(token_s5_details['price_usd'], "N/A")
+        self.assertTrue("pair5miss" in token_s5_details['pair_address_short'])
+        self.assertEqual(token_s5_details['discovered_at'], missing_data_token_time.isoformat())
+
+        # Test with priceUsd being non-numeric string
+        non_numeric_price_token_time = now - timedelta(minutes=2)
+        self.scanner.potential_tokens = [ # Reset to control order
+             self._create_mock_potential_token("addr4", "S4P", "S4", "pair4", 123.0, 10),
+             {
+                'address': 'addr6_badprice', 'symbol': 'S6P', 'pair_address': 'pair6bad',
+                'phase1_discovered_at': non_numeric_price_token_time, 'timestamp': non_numeric_price_token_time,
+                'detailed_pair_data': {'baseToken': {'symbol': 'S6'}, 'priceUsd': "NotANumber"}
+            },
+            self._create_mock_potential_token("addr7", "S7P", "S7", "pair7", 10.0, 1)
+        ]
+        for i, mins_ago in enumerate([10,2,1]): # Update timestamps for these three
+             self.scanner.potential_tokens[i]['phase1_discovered_at'] = now - timedelta(minutes=mins_ago)
+
+
+        metrics_bad_price = self.scanner.get_scanner_metrics()
+        token_s6_details = metrics_bad_price['potential_tokens_recent'][1] # Middle element
+        self.assertEqual(token_s6_details['symbol'], 'S6')
+        self.assertEqual(token_s6_details['price_usd'], "NotANumber") # Should keep original string
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit includes several key updates:

1.  **Fix RugCheck Score Parsing:**
    - Modified `verify_token_safety_rugcheck` in `trading_bot/scanner.py` to robustly parse scores from RugCheck.xyz.
    - Ensures float values (e.g., "16.4") are correctly handled and compared against the threshold.
    - Added validation for score ranges and enhanced logging for score processing.

2.  **Implement Scanner Metrics:**
    - Added a 24-hour resettable counter for unique tokens scanned daily to `TokenScanner`.
    - Implemented `TokenScanner.get_scanner_metrics()` to retrieve:
        - Unique tokens scanned today.
        - Total unique tokens scanned all-time. - Current count of potential tokens. - Details of the 3 most recent potential tokens (symbol, pair address, price, discovery time). - RugCheck JWT status. - Timestamp of the last daily reset.
    - Updated `main.py` to expose these scanner metrics via the `/api/status` endpoint under the `scanner_metrics` key.
    - Renamed the existing trader metrics key in `/api/status` to `trader_metrics` for clarity.

3.  **Update Tests:**
    - Added comprehensive tests for `TokenScanner.get_scanner_metrics` in `trading_bot/tests/test_scanner.py`, covering initial state, data population, daily reset logic, and recent token formatting.
    - Added a specific test case to `test_scanner.py` to verify correct parsing of float scores from RugCheck.
    - Created `trading_bot/tests/test_main.py` with tests for the `/api/status` endpoint in `main.py`, ensuring scanner metrics are correctly integrated into the API response.

These changes address the critical RugCheck score misinterpretation bug and enhance the bot's observability by exposing detailed scanner metrics through the API, which you can use for UI updates or monitoring.